### PR TITLE
Error prevention

### DIFF
--- a/client/nos.lua
+++ b/client/nos.lua
@@ -211,23 +211,25 @@ RegisterNetEvent('nitrous:client:SyncFlames')
 AddEventHandler('nitrous:client:SyncFlames', function(netid, nosid)
     local veh = NetToVeh(netid)
     local myid = GetPlayerServerId(PlayerId())
-    if NOSPFX[GetVehicleNumberPlateText(veh)] == nil then
-        NOSPFX[GetVehicleNumberPlateText(veh)] = {}
-    end
-    if myid ~= nosid then
-        for _,bones in pairs(p_flame_location) do
-            if NOSPFX[GetVehicleNumberPlateText(veh)][bones] == nil then
-                NOSPFX[GetVehicleNumberPlateText(veh)][bones] = {}
-            end
-            if GetEntityBoneIndexByName(veh, bones) ~= -1 then
-                if NOSPFX[GetVehicleNumberPlateText(veh)][bones].pfx == nil then
-                    RequestNamedPtfxAsset(ParticleDict)
-                    while not HasNamedPtfxAssetLoaded(ParticleDict) do
-                        Citizen.Wait(0)
+    if veh then
+        if NOSPFX[GetVehicleNumberPlateText(veh)] == nil then
+            NOSPFX[GetVehicleNumberPlateText(veh)] = {}
+        end
+        if myid ~= nosid then
+            for _,bones in pairs(p_flame_location) do
+                if NOSPFX[GetVehicleNumberPlateText(veh)][bones] == nil then
+                    NOSPFX[GetVehicleNumberPlateText(veh)][bones] = {}
+                end
+                if GetEntityBoneIndexByName(veh, bones) ~= -1 then
+                    if NOSPFX[GetVehicleNumberPlateText(veh)][bones].pfx == nil then
+                        RequestNamedPtfxAsset(ParticleDict)
+                        while not HasNamedPtfxAssetLoaded(ParticleDict) do
+                            Citizen.Wait(0)
+                        end
+                        SetPtfxAssetNextCall(ParticleDict)
+                        UseParticleFxAssetNextCall(ParticleDict)
+                        NOSPFX[GetVehicleNumberPlateText(veh)][bones].pfx = StartParticleFxLoopedOnEntityBone(ParticleFx, veh, 0.0, -0.05, 0.0, 0.0, 0.0, 0.0, GetEntityBoneIndexByName(veh, bones), ParticleSize, 0.0, 0.0, 0.0)
                     end
-                    SetPtfxAssetNextCall(ParticleDict)
-                    UseParticleFxAssetNextCall(ParticleDict)
-                    NOSPFX[GetVehicleNumberPlateText(veh)][bones].pfx = StartParticleFxLoopedOnEntityBone(ParticleFx, veh, 0.0, -0.05, 0.0, 0.0, 0.0, 0.0, GetEntityBoneIndexByName(veh, bones), ParticleSize, 0.0, 0.0, 0.0)
                 end
             end
         end


### PR DESCRIPTION
When a player uses nitrous it tries to sync the flames to all clients. But if the player is out of the scope the users client they will not be able to resolve the entity attached to the network id. Just a simple check if the client was able to resolve an entity from the network id