### PR TITLE
Nos update

### DIFF
--- a/client/nos.lua
+++ b/client/nos.lua
@@ -166,7 +166,7 @@ CreateThread(function()
                 end
             end
         end
-        Wait(0)
+        Wait(20)
     end
 end)
 


### PR DESCRIPTION
Hello.
So I was playing around with nos yesterday and I still got kicked out of the server when just holding nos down so I put a little bit of the delay on syncing flames loop and the sync still works fine as far as I could test it if someone can test this with more people on the server to see if the syncing does not break before merging this PR. btw merry christams

This fixes:
Network event overflow so that players don't get kicked from the server when using NOS