### PR TITLE
Fix the problem with CTRL

### DIFF
--- a/client/nos.lua
+++ b/client/nos.lua
@@ -55,7 +55,7 @@ CreateThread(function()
             local Plate = trim(GetVehicleNumberPlateText(CurrentVehicle))
             if VehicleNitrous[Plate] ~= nil then
                 if VehicleNitrous[Plate].hasnitro then
-                    if IsControlJustPressed(0, 36) and GetPedInVehicleSeat(CurrentVehicle, -1) == PlayerPedId() then
+                    if IsDisabledControlJustPressed(0, 36) and GetPedInVehicleSeat(CurrentVehicle, -1) == PlayerPedId() then
                         SetVehicleEnginePowerMultiplier(CurrentVehicle, NitrousBoost)
                         SetVehicleEngineTorqueMultiplier(CurrentVehicle, NitrousBoost)
                         SetEntityMaxSpeed(CurrentVehicle, 999.0)

--- a/client/nos.lua
+++ b/client/nos.lua
@@ -84,7 +84,7 @@ CreateThread(function()
                         end)
                     end
 
-                    if IsControlJustReleased(0, 36) and GetPedInVehicleSeat(CurrentVehicle, -1) == PlayerPedId() then
+                    if IsDisabledControlJustReleased(0, 36) and GetPedInVehicleSeat(CurrentVehicle, -1) == PlayerPedId() then
                         if NitrousActivated then
                             local veh = GetVehiclePedIsIn(PlayerPedId())
                             SetVehicleBoostActive(veh, 0)


### PR DESCRIPTION
With the old code, we cannot use the nitro as item, because of this. This patch fixes it.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
